### PR TITLE
Fix most examples to work with newer versions of yosys and clang

### DIFF
--- a/blink_introspect/main.cpp
+++ b/blink_introspect/main.cpp
@@ -25,7 +25,7 @@ void dump_all_items(cxxrtl::debug_items &items)
 
 void dump_item_value(cxxrtl::debug_items &items, std::string path)
 {
-    cxxrtl::debug_item item = items.at(path);
+    cxxrtl::debug_item item = items.at(path)[0];
 
     // Number of chunks per value
     const size_t nr_chunks = (item.width + (sizeof(chunk_t) * 8 - 1)) / (sizeof(chunk_t) * 8);
@@ -49,7 +49,7 @@ int main()
 
     cxxrtl::debug_items all_debug_items;
 
-    top.debug_info(all_debug_items);
+    top.debug_info(&all_debug_items, nullptr, "");
 
     dump_all_items(all_debug_items);
 

--- a/blink_vcd/main.cpp
+++ b/blink_vcd/main.cpp
@@ -17,7 +17,7 @@ int main()
     cxxrtl::debug_items all_debug_items;
 
     // Load the debug items of the top down the whole design hierarchy
-    top.debug_info(all_debug_items);
+    top.debug_info(&all_debug_items, nullptr, "");
 
     // vcd_writer is the CXXRTL object that's responsible of creating a string with
     // the VCD file contents.

--- a/cxxrtl/main.cpp
+++ b/cxxrtl/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
 
     cxxrtl_design::p_ExampleTop top;
     cxxrtl::debug_items all_debug_items;
-    top.debug_info(all_debug_items);
+    top.debug_info(&all_debug_items, nullptr, "");
     cxxrtl::vcd_writer vcd;
     std::ofstream waves;
 
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
         else if (dump_level == 2)
             vcd.add_without_memories(all_debug_items);
         else if (dump_level == 3)
-		    vcd.template add(all_debug_items, [](const std::string &, const debug_item &item) {
+		    vcd.add(all_debug_items, [](const std::string &, const debug_item &item) {
 			    return item.type == debug_item::WIRE;
 		    });
         waves.open(filename);
@@ -68,11 +68,11 @@ int main(int argc, char **argv)
     if (dump_level >=1 && dump_level <= 3)
         vcd.sample(0);
 
-    cxxrtl::debug_item psel    = all_debug_items.at("cpu_u_cpu u_uart io_apb_PSEL");
-    cxxrtl::debug_item penable = all_debug_items.at("cpu_u_cpu u_uart io_apb_PENABLE");
-    cxxrtl::debug_item pwrite  = all_debug_items.at("cpu_u_cpu u_uart io_apb_PWRITE");
-    cxxrtl::debug_item pwdata  = all_debug_items.at("cpu_u_cpu u_uart io_apb_PWDATA");
-    cxxrtl::debug_item paddr   = all_debug_items.at("cpu_u_cpu u_uart io_apb_PADDR");
+    cxxrtl::debug_item psel    = all_debug_items.at("cpu_u_cpu u_uart io_apb_PSEL")[0];
+    cxxrtl::debug_item penable = all_debug_items.at("cpu_u_cpu u_uart io_apb_PENABLE")[0];
+    cxxrtl::debug_item pwrite  = all_debug_items.at("cpu_u_cpu u_uart io_apb_PWRITE")[0];
+    cxxrtl::debug_item pwdata  = all_debug_items.at("cpu_u_cpu u_uart io_apb_PWDATA")[0];
+    cxxrtl::debug_item paddr   = all_debug_items.at("cpu_u_cpu u_uart io_apb_PADDR")[0];
 
     int led_red_cntr = 0;
 

--- a/rpu_vhdl/main.cpp
+++ b/rpu_vhdl/main.cpp
@@ -3,7 +3,7 @@
 #include <fstream>
 #include <iomanip>
 
-#include <backends/cxxrtl/cxxrtl_vcd.h>
+#include <cxxrtl/cxxrtl_vcd.h>
 
 #include <cxxrtl_lib.h>
 
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
 
     cxxrtl_design::p_ExampleTop top;
     cxxrtl::debug_items all_debug_items;
-    top.debug_info(all_debug_items);
+    top.debug_info(&all_debug_items, nullptr, "");
     cxxrtl::vcd_writer vcd;
     std::ofstream waves;
 
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
         else if (dump_level == 2)
             vcd.add_without_memories(all_debug_items);
         else if (dump_level == 3)
-		    vcd.template add(all_debug_items, [](const std::string &, const debug_item &item) {
+		    vcd.add(all_debug_items, [](const std::string &, const debug_item &item) {
 			    return item.type == debug_item::WIRE;
 		    });
         waves.open(filename);
@@ -68,11 +68,11 @@ int main(int argc, char **argv)
     if (dump_level >=1 && dump_level <= 3)
         vcd.sample(0);
 
-    cxxrtl::debug_item psel    = all_debug_items.at("cpu_u_cpu u_uart io_apb_PSEL");
-    cxxrtl::debug_item penable = all_debug_items.at("cpu_u_cpu u_uart io_apb_PENABLE");
-    cxxrtl::debug_item pwrite  = all_debug_items.at("cpu_u_cpu u_uart io_apb_PWRITE");
-    cxxrtl::debug_item pwdata  = all_debug_items.at("cpu_u_cpu u_uart io_apb_PWDATA");
-    cxxrtl::debug_item paddr   = all_debug_items.at("cpu_u_cpu u_uart io_apb_PADDR");
+    cxxrtl::debug_item psel    = all_debug_items.at("cpu_u_cpu u_uart io_apb_PSEL")[0];
+    cxxrtl::debug_item penable = all_debug_items.at("cpu_u_cpu u_uart io_apb_PENABLE")[0];
+    cxxrtl::debug_item pwrite  = all_debug_items.at("cpu_u_cpu u_uart io_apb_PWRITE")[0];
+    cxxrtl::debug_item pwdata  = all_debug_items.at("cpu_u_cpu u_uart io_apb_PWDATA")[0];
+    cxxrtl::debug_item paddr   = all_debug_items.at("cpu_u_cpu u_uart io_apb_PADDR")[0];
 
     int led_red_cntr = 0;
 

--- a/rpu_vhdl/run.sh
+++ b/rpu_vhdl/run.sh
@@ -17,5 +17,5 @@ cp ../spinal/*symbol*.bin .
 
 yosys -m ghdl -p "read_verilog ../spinal/ExampleTop.sim.v; delete VexRiscv; read_verilog VexRiscv_wrapper.v; ghdl --std=08 core; hierarchy -check -top ExampleTop; write_cxxrtl -Og ExampleTop.sim.cpp"
 
-clang++-9 -g -O3 -I`yosys-config --datdir`/include -DEXAMPLE_TOP=\"ExampleTop.sim.cpp\" -std=c++14 -I../lib main.cpp ../lib/cxxrtl_lib.cpp -o tb
+clang++-9 -g -O3 -I`yosys-config --datdir`/include/backends/cxxrtl/runtime -DEXAMPLE_TOP=\"ExampleTop.sim.cpp\" -std=c++14 -I../lib main.cpp ../lib/cxxrtl_lib.cpp -o tb
 ./tb 2 waves.vcd

--- a/save_restore/Makefile
+++ b/save_restore/Makefile
@@ -1,22 +1,23 @@
 
-YOSYS_DIR	= ~/projects/yosys
+YOSYS = yosys
+YOSYS_INCLUDE	= $(shell yosys-config --datdir)/include/backends/cxxrtl/runtime
 
 all: tb_save tb_restore
 	./tb_save
 	./tb_restore
 
 tb_save: save.cpp blink.cpp cxxrtl_lib.o
-	clang++ -g -O0 -std=c++14 -I $(YOSYS_DIR) -I../lib cxxrtl_lib.o $< -o $@
+	clang++ -g -O0 -std=c++14 -I $(YOSYS_INCLUDE) -I../lib cxxrtl_lib.o $< -o $@
 
 tb_restore: restore.cpp blink.cpp cxxrtl_lib.o
-	clang++ -g -O0 -std=c++14 -I $(YOSYS_DIR) -I../lib cxxrtl_lib.o $< -o $@
+	clang++ -g -O0 -std=c++14 -I $(YOSYS_INCLUDE) -I../lib cxxrtl_lib.o $< -o $@
 
 blink.cpp: blink.v
-	$(YOSYS_DIR)/yosys -p "read_verilog blink.v; hierarchy -top blink; write_cxxrtl -Og blink.cpp"
+	$(YOSYS) -p "read_verilog blink.v; hierarchy -top blink; write_cxxrtl -Og blink.cpp"
 
 
 cxxrtl_lib.o: ../lib/cxxrtl_lib.cpp
-	clang++ -c -g -std=c++14 -I $(YOSYS_DIR) -I../lib $< 
+	clang++ -c -g -std=c++14 -I $(YOSYS_INCLUDE) -I../lib $<
 
 clean:
 	\rm -f blink.cpp tb *.vcd

--- a/save_restore/restore.cpp
+++ b/save_restore/restore.cpp
@@ -16,7 +16,7 @@ int main()
 
     cxxrtl::debug_items all_debug_items;
 
-    top.debug_info(all_debug_items);
+    top.debug_info(&all_debug_items, nullptr, "");
 
     cout << "Restoring from checkpoint..." << endl;
     std::ifstream checkpoint("checkpoint.val");

--- a/save_restore/save.cpp
+++ b/save_restore/save.cpp
@@ -15,7 +15,7 @@ int main()
 
     cxxrtl::debug_items all_debug_items;
 
-    top.debug_info(all_debug_items);
+    top.debug_info(&all_debug_items, nullptr, "");
 
     // Print all the introspectable information of all debug items
     for(auto &it : all_debug_items.table)


### PR DESCRIPTION
Developed with:
clang version 19.1.6
yosys version 0.47

The vhdl example has further issues, I didn't want to set up a build environment for spinal.

They still seem to work correctly afterwards, as far as I can tell. I have no Idea if the adjustments for the changed cxxrtl API are entirely correct, but they seem reasonable.